### PR TITLE
correction: echo needs -e flag to process \n and \t

### DIFF
--- a/README.md
+++ b/README.md
@@ -1903,7 +1903,7 @@ In the `rat` Namespace (create if required), create a Pod named `webapp` that ru
 The Pod should have an _Init Container_ named `web-init`, running `busybox:1.28` image, that creates a file in the same `emptyDir` volume, mounted to `/tempdir`, with below command:
 
 ```sh
-echo "server {\n\tlisten\t${NGINX_PORT};\n\n\tlocation / {\n\t\troot\t/usr/share/nginx/html;\n\t}\n}" > /tempdir/default.conf.template
+echo -e "server {\n\tlisten\t${NGINX_PORT};\n\n\tlocation / {\n\t\troot\t/usr/share/nginx/html;\n\t}\n}" > /tempdir/default.conf.template
 ```
 
 </div>
@@ -1953,9 +1953,9 @@ echo "server {\n\tlisten\t${NGINX_PORT};\n\n\tlocation / {\n\t\troot\t/usr/share
   command:
   - /bin/sh
   - -c
-  - echo "..." > /temp...
+  - echo -e "..." > /temp...
   # array form with single quotes
-  command: ["/bin/sh", "-c", "echo '...' > /temp..."]
+  command: ["/bin/sh", "-c", "echo -e '...' > /temp..."]
   ```
   </details>
 

--- a/README.md
+++ b/README.md
@@ -1903,7 +1903,7 @@ In the `rat` Namespace (create if required), create a Pod named `webapp` that ru
 The Pod should have an _Init Container_ named `web-init`, running `busybox:1.28` image, that creates a file in the same `emptyDir` volume, mounted to `/tempdir`, with below command:
 
 ```sh
-echo -e "server {\n\tlisten\t${NGINX_PORT};\n\n\tlocation / {\n\t\troot\t/usr/share/nginx/html;\n\t}\n}" > /tempdir/default.conf.template
+echo -e "server {\n\tlisten\t\${NGINX_PORT};\n\n\tlocation / {\n\t\troot\t/usr/share/nginx/html;\n\t}\n}" > /tempdir/default.conf.template
 ```
 
 </div>


### PR DESCRIPTION
without this, the init pod was failing continuously
```yaml
# webapp.yaml
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: null
  labels:
    run: webapp
  name: webapp
  namespace: rat
spec:
  volumes:
  - name: myvol
    emptyDir: {}
  initContainers:
  - env:
    - name: NGINX_PORT
      value: "3005"
    image: busybox:1.28
    volumeMounts:
    - name: myvol
      mountPath: /tempdir
    name: web-init
    args:
    - /bin/sh
    - -c
    - echo -e "server {\n\tlisten\t${NGINX_PORT};\n\n\tlocation / {\n\t\troot\t/usr/share/nginx/html;\n\t}\n}" > /tempdir/default.conf.template
  containers:
  - env:
    - name: NGINX_PORT
      value: "3005"
    image: nginx:1.22-alpine
    volumeMounts:
    - name: myvol
      mountPath: /etc/nginx/templates
    name: web
    ports:
    - containerPort: 3005
    resources: {}
  dnsPolicy: ClusterFirst
  restartPolicy: Always
status: {}
```